### PR TITLE
Add support for overriding variables in device-specific context

### DIFF
--- a/build.py
+++ b/build.py
@@ -272,7 +272,7 @@ def read_config_data(path, vlan_map, override=False):
                 else:
                     combine_config_data(devices[device_name], new, filename, override)
             else:
-                combine_config_data(config_data, new, filename, override)
+                combine_config_data(config_data, new, filename)
 
     # If we have a vlan map, we create interface configs from it, and add them
     # to the device specific config.
@@ -384,7 +384,7 @@ def render(devices, template, config_data):
             device_specific = devices[opts.device]
             if not device_specific:
                 abort("The length of the device specific data for %s is 0. Perhaps empty file?!" % opts.device)
-            combine_config_data(config_data, device_specific, opts.device)
+            combine_config_data(config_data, device_specific, opts.device, opts.allow_override)
         else:
             abort("Couldn't find a _device_specific.yaml for %s" % opts.device)
 

--- a/build.py
+++ b/build.py
@@ -210,8 +210,8 @@ def combine_config_data(base, new, filename, override=False):
     Returns:
         Dictionary of base + new
     """
-    for key in new.keys():
-        if not override:
+    if not override:
+        for key in new.keys():
             if key in base:
                 abort('The variable "%s" loaded from %s already exists in the config data.' % (key, filename))
     return base.update(new)


### PR DESCRIPTION
Provide an option that allows for device-specific variables to override base variables.  By default, this option is False to retain existing functionality.